### PR TITLE
Fix Helios scanner integration and clean up dependencies

### DIFF
--- a/Custom Packages/helios-patched/helios/main.py
+++ b/Custom Packages/helios-patched/helios/main.py
@@ -142,7 +142,7 @@ def main(url, scan_type):
 
     instance = helios.Helios(opts)
     try:
-        instance.run(urls, opts.scopes)
+        return instance.run(urls, opts.scopes)
     except KeyboardInterrupt:
         instance.logger.warning("KeyboardInterrupt received, shutting down")
         instance.db.end()

--- a/Custom Packages/helios-patched/setup.py
+++ b/Custom Packages/helios-patched/setup.py
@@ -37,7 +37,7 @@ setup(
         'console_scripts': ['helios=helios.main:main', 'helios-update-db=helios.webapp.databases.update:main'],
     },
     install_requires=[
-        'pyOpenSSL>=0.14'
+        'pyOpenSSL>=0.14',
         'beautifulsoup4',
         'requests',
         'selenium',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # for all
-json==2.0.9
 Flask==2.1.1
 requests==2.26.0
 python-owasp-zap-v2.4==0.0.21
@@ -7,8 +6,4 @@ DateTime==4.9
 
 
 # for scheduler
-datetime
-sqlite3
-time
-requests
 # need versions of these packages


### PR DESCRIPTION
### Description
This PR resolves issues with the local `helios` custom package integration (allowing programmatic access to scan results) and cleans up invalid and redundant dependencies from the project requirements. 

Fixies Bug:  [Issue#31](https://github.com/Risk-Assessment-Framework/RAF-DAST-Scanner/issues/31)

### Changes Made
**1. Dependency Cleanup (`requirements.txt`)**
- Removed Python built-in modules (`json`, `datetime`, `sqlite3`, `time`) that were incorrectly listed as package dependencies.
- Removed the duplicate entry for `requests`.

**2. Helios Package Fixes (`Custom Packages/helios-patched/`)**
- **`setup.py`**: Fixed a missing comma in the `install_requires` list that was preventing the correct installation of Helios dependencies.
- **`helios/main.py`**: Updated the `main` execution function to actually `return` the scan results (`return instance.run(...)`). Previously, results were being dropped, but now they can be reliably consumed by external wrapper scripts.
